### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ You can now start the `present` tool in the root of this repository:
 present -base . -content .
 ```
 
- Open your web browser and visit [http://127.0.0.1:3999]().
+ Open your web browser and visit http://127.0.0.1:3999.


### PR DESCRIPTION
Empty parentheses represent an empty link which eventually leads to the repo itself. The hyperlink can be set without any text to just be a normal URL.